### PR TITLE
bug fix: `cstag.consensus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ print(cstag.call(cigar, md, seq))
 # :2*ag:5-ag:4+ac~nn3nn:1
 
 cstag.call(cigar, md, seq, long=True)
-#  =AC*ag=TACGT-ag=ACGT+ac~nn3nn=G
+# =AC*ag=TACGT-ag=ACGT+ac~nn3nn=G
 ```
 
 ### Shorten or Lengthen CS Tags
@@ -63,7 +63,7 @@ import cstag
 cs = "=ACGT*ag=CGT"
 
 cstag.shorten(cs)
-#  :4*ag:3
+# :4*ag:3
 
 
 # Convert a CS tag from short to long
@@ -72,7 +72,7 @@ cigar = "8M"
 seq = "ACGTACGT"
 
 cstag.lengthen(cs, cigar, seq)
-#  =ACGT*ag=CGT
+# =ACGT*ag=CGT
 ```
 
 ### Generate a Consensus
@@ -80,12 +80,11 @@ cstag.lengthen(cs, cigar, seq)
 ```python
 import cstag
 
-cs_list = ["=ACGT", "=AC*gt=T", "=C*gt=T", "=C*gt=T", "=ACT+ccc=T"]
-cigar_list = ["4M", "4M", "1S3M", "3M", "3M3I1M"]
-pos_list = [1, 1, 1, 2, 1]
+cs_tags = ["=ACGT", "=AC*gt=T", "=C*gt=T", "=C*gt=T", "=ACT+ccc=T"]
+positions = [1, 1, 2, 2, 1]
 
-cstag.consensus(cs_list, cigar_list, pos_list)
-#  =AC*gt*T
+cstag.consensus(cs_tags, positions)
+# =AC*gt*T
 ```
 
 ### Mask Low-Quality Bases
@@ -98,7 +97,7 @@ cigar = "5M2I2D1M"
 qual = "AA!!!!AA"
 phred_threshold = 10
 cstag.mask(cs, cigar, qual, phred_threshold)
-#  =ACNN*an+ng-cc=T
+# =ACNN*an+ng-cc=T
 ```
 
 ### Split a CS Tag
@@ -108,7 +107,7 @@ import cstag
 
 cs = "=ACGT*ac+gg-cc=T"
 cstag.split(cs)
-#  ['=ACGT', '*ac', '+gg', '-cc', '=T']
+# ['=ACGT', '*ac', '+gg', '-cc', '=T']
 ```
 
 ### Reverse Complement of a CS Tag
@@ -118,7 +117,7 @@ import cstag
 
 cs = "=ACGT*ac+gg-cc=T"
 cstag.revcomp(cs)
-#  =A-gg+cc*tg=ACGT
+# =A-gg+cc*tg=ACGT
 ```
 
 ### Generate VCF Report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "cstag"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python module to manipulate the minimap2's CS tag"
 authors = ["Akihiro Kuno <akuno@md.tsukuba.ac.jp>"]
 homepage = "https://github.com/akikuno/cstag"

--- a/tests/test_consensus.py
+++ b/tests/test_consensus.py
@@ -1,35 +1,10 @@
 from collections import deque
 from src.cstag.consensus import (
-    extract_softclips,
-    calculate_read_starts,
     split_cs_tags,
     normalize_read_lengths,
     get_consensus,
     consensus,
 )
-
-
-def test_extract_softclips():
-    # Test with a variety of CIGAR strings
-    cigar_strings = ["4S3M", "3M4S", "10M", "5S5M5S", "5M"]
-    expected_output = [4, 0, 0, 5, 0]
-
-    assert extract_softclips(cigar_strings) == expected_output
-
-    # Test with empty CIGAR string
-    assert extract_softclips([""]) == [0]
-
-    # Test with no CIGAR strings
-    assert extract_softclips([]) == []
-
-
-def test_calculate_read_starts():
-    # Test with a variety of POS and CIGAR strings
-    POS = [6, 8, 10]
-    CIGAR = ["4S3M", "3M", "3S2M"]
-    expected_output = [0 + 4, 2 + 0, 4 + 3]
-
-    assert calculate_read_starts(POS, CIGAR) == expected_output
 
 
 def test_split_cs_tags():
@@ -96,30 +71,26 @@ def test_substitution():
         "=C*gt=T",
         "=ACT+ccc=T",
     ]
-    CIGAR = ["4M", "4M", "1S3M", "3M", "3M3I1M"]
-    POS = [1, 1, 1, 2, 1]
-    assert consensus(CSTAG, CIGAR, POS) == "=AC*gt=T"
+    POS = [1, 1, 2, 2, 1]
+    assert consensus(CSTAG, POS) == "=AC*gt=T"
 
 
 def test_insertion():
     CSTAG = ["=ACGT", "=AC+ggggg=GT", "=C+ggggg=GT", "=C+ggggg=GT"]
-    CIGAR = ["4M", "2M5I1M", "1S5I3M", "1M5I1M"]
-    POS = [1, 1, 1, 2]
-    assert consensus(CSTAG, CIGAR, POS) == "=NC+ggggg=GT"
+    POS = [1, 1, 2, 2]
+    assert consensus(CSTAG, POS) == "=NC+ggggg=GT"
 
 
 def test_deletion():
     CSTAG = ["=ACGT", "=AC-ggggg=GT", "=C-ggggg=GT", "=C-ggggg=GT"]
-    CIGAR = ["4M", "2M5D1M", "1S5D3M", "1M5D1M"]
-    POS = [1, 1, 1, 2]
-    assert consensus(CSTAG, CIGAR, POS) == "=NC-ggggg=GT"
+    POS = [1, 1, 2, 2]
+    assert consensus(CSTAG, POS) == "=NC-ggggg=GT"
 
 
-def test_softclip():
+def test_positions():
     CSTAG = ["=ACGT", "=CGT", "=GT"]
-    CIGAR = ["4M", "1S3M", "2S2M"]
-    POS = [1, 1, 1]
-    assert consensus(CSTAG, CIGAR, POS) == "=NCGT"
+    POS = [1, 2, 3]
+    assert consensus(CSTAG, POS) == "=NCGT"
 
 
 def test_splicing():
@@ -129,6 +100,5 @@ def test_splicing():
         "=C~gc100ag=T",
         "=C~gc100ag=T",
     ]
-    CIGAR = ["4M", "2M100N1M", "1S100N3M", "1M100N1M"]
-    POS = [1, 1, 1, 2]
-    assert consensus(CSTAG, CIGAR, POS) == "=NC~gc100ag=T"
+    POS = [1, 1, 2, 2]
+    assert consensus(CSTAG, POS) == "=NC~gc100ag=T"


### PR DESCRIPTION
+ POS does not consider CIGAR's softclips, so removed `extract_softclips` and `calculate_read_starts` function