### PR TITLE
Develop-v1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "cstag"
-version = "1.0.1"
+version = "1.0.2"
 description = "Python module to manipulate the minimap2's CS tag"
 authors = ["Akihiro Kuno <akuno@md.tsukuba.ac.jp>"]
 homepage = "https://github.com/akikuno/cstag"

--- a/src/cstag/to_vcf.py
+++ b/src/cstag/to_vcf.py
@@ -196,10 +196,9 @@ def call_reference_depth(variant_annotations, cs_tags_list, positions_list) -> d
     cs_tags_normalized_length = normalize_read_lengths(cs_tags_list, positions_list)
     # Call ref depth
     reference_depth = defaultdict(int)
-    ACGT = {"A", "C", "G", "T"}
     for i, v_pos in zip(variant_idx, variant_pos):
         for cs in cs_tags_normalized_length:
-            if cs[i][0] in ACGT:
+            if cs[i][0] and cs[i][0] in "ACGT":
                 reference_depth[v_pos] += 1
 
     return dict(reference_depth)

--- a/tests/test_to_vcf.py
+++ b/tests/test_to_vcf.py
@@ -12,6 +12,7 @@ from src.cstag.to_vcf import (
     format_cs_tags,
     group_by_chrom,
     group_by_overlapping_intervals,
+    call_reference_depth,
     add_vcf_fields,
     process_cs_tag,
     process_cs_tags,
@@ -160,6 +161,22 @@ def test_group_by_overlapping_intervals():
 ###########################################################
 # Add VCF info
 ###########################################################
+
+
+def test_call_reference_depth():
+    variant_annotations = [
+        Vcf(pos=11, ref="C", alt="G"),
+        Vcf(pos=12, ref="G", alt="GAA"),
+        Vcf(pos=13, ref="TAC", alt="T"),
+        Vcf(pos=11, ref="C", alt="G"),
+        Vcf(pos=12, ref="G", alt="GAA"),
+    ]
+    cs_tags_list = ["=A*cg=G+aa=T-ac=G", "*cg=G+aa=T-ac=G", "=G-t=ACG"]
+    positions_list = [10, 11, 12]
+    expected_output = {12: 1}
+
+    result = call_reference_depth(variant_annotations, cs_tags_list, positions_list)
+    assert result == expected_output, f"Expected {expected_output}, but got {result}"
 
 
 def test_add_vcf_fields():


### PR DESCRIPTION
+ Fixed a calculation error in RD in `to_vcf.call_reference_depth`
  + Previously, only the Cs tags that matched the reference were considered, resulting in a match (adding 1 to RD) for sequences like deletions (e.g., `=T, -c, -c`).
  + Changed the policy to add 1 to RD if the sequence corresponding to `v.ref` exists in the CS tags.

+ Due to the change in `cstag.consensus.normalize_read_lengths` in v1.0.1, where insufficient read lengths are now padded with `None` instead of `N`, a bug arose in `to_vcf.call_reference_depth` where it referred to `None`. This has been fixed.